### PR TITLE
Add explicit trailing slash when saving question

### DIFF
--- a/qq
+++ b/qq
@@ -24,7 +24,7 @@ then
     echo "example: ${0##*/} -a \"What is the meaning of life?\" \"42\""
     exit 1
   fi
-  echo -n "$ANSWER" > "${NOTESDIR}$NOTESPRE $QUESTION.$NOTESEXT"
+  echo -n "$ANSWER" > "${NOTESDIR}/$NOTESPRE $QUESTION.$NOTESEXT"
   echo "Question added and answered."
 elif [[ "$1" == "-e" ]]; then
   shift


### PR DESCRIPTION
If the trailing slash is omitted from the `NOTESDIR` declaration,
QuickQuestion behaves a little unexpectedly. A note is written one
directory up from where you expect, with the last `NOTESDIR` component
included in the prefix.

For example, before the change:

```
NOTESDIR="/path/to/some/dir"
NOTESEXT="txt"
NOTESPRE="qq"
# ...
qq -a "question" "answer"
ls /path/to/some
# dirqq question.txt
```

After the change:

```
NOTESDIR="/path/to/some/dir"
NOTESEXT="txt"
NOTESPRE="qq"
# ...
qq -a "question" "answer"
ls /path/to/some/dir
# qq question.txt
```

If `NOTESDIR` itself includes a trailing slash, everything still works
as before.

Admittedly this is for saving the user from himself.
